### PR TITLE
ci/grant write permissions

### DIFF
--- a/.github/workflows/regenerate-lockfile.yml
+++ b/.github/workflows/regenerate-lockfile.yml
@@ -1,3 +1,7 @@
+
+permissions:
+  contents: write
+
 name: Regenerate lockfile (linux)
 
 on:


### PR DESCRIPTION
- **ci: generate package-lock on linux with npm install --package-lock-only**
- **ci: allow workflow to push package-lock (contents: write)**
